### PR TITLE
feat: 'latest' switch, option to specify exact version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # GKE upgrade tool
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Local](#local)
+  - [Docker](#docker)
+  - [GitHub Actions](#github-actions)
+- [Example](#example)
+
 ## Overview
 
 This tool is designed to help upgrading GKE versions in KBC stacks `env.yaml` files. It handles switching between active node pools and upgrading them.
@@ -8,10 +19,18 @@ What it does is:
 
 - Fetches latest GKE versions from their *no-channel* [feed](https://cloud.google.com/kubernetes-engine/docs/release-notes-nochannel)
 - Checks for the GKE version in the `env.yaml` file
-- Searches for the latest build and/or patch version of a specified minor version
+- Searches for the second to latest build and/or patch version of a specified minor version
 - Switches between A/B node pools
 - Upgrades the newly activated node pool
 - If run again, upgrades the previously active node pool as well
+
+You can alter this behavior with the following options:
+
+- `--minor` to specify a minor version to upgrade to, e.g. `1.26`
+- `--latest` to upgrade to the latest available version, instead of the second to latest
+- `--image` to upgrade to a specific version, e.g. `1.25.16-gke.1041000`
+
+Please note, that `--minor/--latest` and `--image` are mutually exclusive.
 
 ## Requirements
 
@@ -36,6 +55,12 @@ gke-upgrade-tool /path/to/your/env.yaml
 
 # Or specify minor version to upgrade to
 gke-upgrade-tool /path/to/your/env.yaml -m 1.26
+
+# Use the latest GKE version of the specified minor version
+gke-upgrade-tool /path/to/your/env.yaml -m 1.26 -l
+
+# Upgrade to a specific GKE version
+gke-upgrade-tool /path/to/your/env.yaml -i 1.25.16-gke.1041000
 ```
 
 ### Docker
@@ -70,6 +95,14 @@ on:
         description: "GKE minor version to upgrade to, leave empty to use minor version from env.yaml"
         required: false
         type: string
+      use-latest:
+        description: "Use the latest GKE version"
+        required: false
+        type: boolean
+      specific-version:
+        description: "Specific GKE version to upgrade to"
+        required: false
+        type: string
       jira-ticket:
         description: "Related JIRA ticket"
         required: false
@@ -92,6 +125,8 @@ jobs:
         with:
           kbc-stack: ${{ inputs.kbc-stack }}
           gke-minor-version: ${{ inputs.gke-minor-version }}
+          use-latest: ${{ inputs.use-latest }}
+          specific-version: ${{ inputs.specific-version }}
           jira-ticket: ${{ inputs.jira-ticket }}
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -7,8 +7,15 @@ inputs:
   gke-minor-version:
     description: "GKE minor version to upgrade to"
     required: false
+  use-latest:
+    description: "Use the latest GKE version"
+    required: false
+    default: "true"
   jira-ticket:
     description: "Related JIRA ticket"
+    required: false
+  specific-version:
+    description: "Specific GKE version to upgrade to"
     required: false
 
 runs:
@@ -28,11 +35,17 @@ runs:
         pip install gke*.tar.gz
         git config user.name github-actions
         git config user.email github-actions@github.com
+        GKE_TOOL_ARGS=${{ inputs.kbc-stack }}/terraform/env.yaml
         if [ -n "${{ inputs.gke-minor-version }}" ]; then
-          echo "GKE_TOOL_ARGS=${{ inputs.kbc-stack }}/terraform/env.yaml -m ${{ inputs.gke-minor-version }}" >> $GITHUB_ENV
-        else
-          echo "GKE_TOOL_ARGS=${{ inputs.kbc-stack }}/terraform/env.yaml" >> $GITHUB_ENV
+          GKE_TOOL_ARGS+=" -m ${{ inputs.gke-minor-version }}"
         fi
+        if [ "${{ inputs.use-latest }}" == "true" ]; then
+          GKE_TOOL_ARGS+=" -l"
+        fi
+        if [ -n "${{ inputs.specific-version }}" ]; then
+          GKE_TOOL_ARGS+=" -i ${{ inputs.specific-version }}"
+        fi
+        echo "GKE_TOOL_ARGS=${GKE_TOOL_ARGS}" >> $GITHUB_ENV
         if [ -n "${{ inputs.jira-ticket }}" ]; then
           PR_BODY=$(
           cat <<END_HEREDOC

--- a/gke_upgrade_tool/main.py
+++ b/gke_upgrade_tool/main.py
@@ -26,6 +26,7 @@ GKE_RELEASE_NOTES = "https://cloud.google.com/feeds/gke-no-channel-release-notes
 parser = argparse.ArgumentParser()
 parser.add_argument("env_file", help="Path to env.yaml file")
 parser.add_argument("-m", "--minor", help="GKE minor version to search for")
+parser.add_argument("-i", "--image", help="Use specific image version for GKE upgrade")
 args = parser.parse_args()
 
 yaml = ruamel.yaml.YAML()
@@ -139,6 +140,8 @@ def main():
 
     if args.minor:
         new_gke_version = latest_gke_version(args.minor)
+    elif args.image:
+        new_gke_version = args.image
     else:
         new_gke_version = latest_gke_version(current_gke_version())
 

--- a/gke_upgrade_tool/main.py
+++ b/gke_upgrade_tool/main.py
@@ -1,14 +1,19 @@
-"""Script that checks latest GKE version available
+"""Script that checks available GKE versions
 for specified minor version, switches active A/B node pools and
 updates GKE version in specified env.yaml file.
 
 Usage:
     gke-upgrade-tool <env_file>
     gke-upgrade-tool <env_file> -m <minor_version>
+    gke-upgrade-tool <env_file> -i <exact_gke_build_version>
+    gke-upgrade-tool <env_file> -l
+    gke-upgrade-tool <env_file> -m <minor_version> -l
 
 Example:
     gke-upgrade-tool kbc-stack/terraform/env.yaml
     gke-upgrade-tool kbc-stack/terraform/env.yaml -m 1.15
+    gke-upgrade-tool kbc-stack/terraform/env.yaml -m 1.15 -l
+    gke-upgrade-tool kbc-stack/terraform/env.yaml -i 1.27.11-gke.1202000
 """
 
 import argparse
@@ -22,11 +27,16 @@ from semver.version import Version
 
 GKE_RELEASE_NOTES = "https://cloud.google.com/feeds/gke-no-channel-release-notes.xml"
 
-# Parse arguments: env.yaml file path, GKE minor version
+# Parse arguments: env.yaml file path, GKE minor version, latest flag, image version
 parser = argparse.ArgumentParser()
 parser.add_argument("env_file", help="Path to env.yaml file")
-parser.add_argument("-m", "--minor", help="GKE minor version to search for")
+
 parser.add_argument("-i", "--image", help="Use specific image version for GKE upgrade")
+parser.add_argument("-m", "--minor", help="GKE minor version to search for")
+parser.add_argument(
+    "-l", "--latest", action="store_true", help="Use latest image for specified version"
+)
+
 args = parser.parse_args()
 
 yaml = ruamel.yaml.YAML()
@@ -54,31 +64,41 @@ if args.minor:
         )
 
 
-def latest_gke_version(minor_version):
+def latest_gke_version(minor_version, latest=False):
     """Parses GKE release notes feed and returns latest version
     for specified minor version"""
     response = requests.get(GKE_RELEASE_NOTES, timeout=10)
     root = ET.fromstring(response.content)
+    first_match_found = False
     for entry in root.findall("{http://www.w3.org/2005/Atom}entry"):
         content = entry.find("{http://www.w3.org/2005/Atom}content").text
         if minor_version in content:
-            result = re.findall(r'<a href=".*?">(.*?)</a>', content)
-            unique_values = sorted(list(set(result)), reverse=True)
-            latest_gke_versions = sorted(
-                [value for value in unique_values if minor_version in value],
-                reverse=True,
-            )
-            if latest_gke_versions:
-                os.environ["LATEST_GKE_VERSION"] = latest_gke_versions[0]
-                print(
-                    f"🎉 Latest GKE version for minor version "
-                    f"{minor_version} is: {latest_gke_versions[0]}"
+            if first_match_found or latest:
+                result = re.findall(r'<a href=".*?">(.*?)</a>', content)
+                unique_values = sorted(list(set(result)), reverse=True)
+                latest_gke_versions = sorted(
+                    [value for value in unique_values if minor_version in value],
+                    reverse=True,
                 )
-                return latest_gke_versions[0]
-            print(
-                f"😬 No matching GKE version found for minor version "
-                f"{minor_version}. Versions available are: {unique_values}"
-            )
+                if latest_gke_versions:
+                    os.environ["LATEST_GKE_VERSION"] = latest_gke_versions[0]
+                    version_string = (
+                        "Second to latest"
+                        if first_match_found and not latest
+                        else "Latest"
+                    )
+                    print(
+                        f"🎉 {version_string} GKE version for minor version "
+                        f"{minor_version} is: {latest_gke_versions[0]}"
+                    )
+                    return latest_gke_versions[0]
+                print(
+                    f"😬 No matching GKE version found for minor version "
+                    f"{minor_version}. Versions available are: {unique_values}"
+                )
+            else:
+                first_match_found = True
+    return None
 
 
 def current_gke_version():
@@ -138,12 +158,15 @@ def update_gke_version(pool_to_update, gke_version):
 def main():
     """Main function"""
 
+    if args.image and (args.minor or args.latest):
+        parser.error("--image cannot be used together with --minor or --latest")
+
     if args.minor:
-        new_gke_version = latest_gke_version(args.minor)
+        new_gke_version = latest_gke_version(args.minor, args.latest)
     elif args.image:
         new_gke_version = args.image
     else:
-        new_gke_version = latest_gke_version(current_gke_version())
+        new_gke_version = latest_gke_version(current_gke_version(), args.latest)
 
     if (
         new_gke_version not in yaml_content["MAIN_NODE_POOL_A_KUBERNETES_VERSION"]


### PR DESCRIPTION
The tool will now prefer second to latest found GKE version, rather than latest. [It can cause issues](https://dev.azure.com/keboola-prod/Keboola%20Connection%20GCP/_releaseProgress?_a=release-environment-logs&releaseId=6823&environmentId=13460), due to GCP slowly rolling out newest version over days.

This update then allows:
- Specyfing `--latest` to use truly latest version of found GKE version
- Specyfing `--image` with exact image version to be used, like `1.27.11-gke.1118000`

`--latest/--minor` and `--image` are mutually exclusive, it will throw error, if you try to use both of them together.