### PR TITLE
feat: Switching nodepools as a standalone step

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies
@@ -44,27 +44,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata for the Docker image
         id: meta
-        uses: docker/metadata-action@v5.5.0
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push image
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v6
         with:
           context: "{{defaultContext}}:gke_upgrade_tool"
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ cython_debug/
 #.idea/
 
 env.yaml
+
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -23,12 +23,15 @@ What it does is:
 - Switches between A/B node pools
 - Upgrades the newly activated node pool
 - If run again, upgrades the previously active node pool as well
+- Upgrades the control plane and non-active nodepools to the new version (by default, does NOT switch active/non-active nodepools)
+- You can switch active/non-active nodepools separately using the `--switch-active-only` flag
 
 You can alter this behavior with the following options:
 
 - `--minor` to specify a minor version to upgrade to, e.g. `1.26`
 - `--latest` to upgrade to the latest available version, instead of the second to latest
 - `--image` to upgrade to a specific version, e.g. `1.25.16-gke.1041000`
+- `--switch-active-only` to only switch all *_NODE_POOL_ACTIVE values between a and b, without touching any Kubernetes version fields (see below)
 
 Please note, that `--minor/--latest` and `--image` are mutually exclusive.
 
@@ -61,6 +64,9 @@ gke-upgrade-tool /path/to/your/env.yaml -m 1.26 -l
 
 # Upgrade to a specific GKE version
 gke-upgrade-tool /path/to/your/env.yaml -i 1.25.16-gke.1041000
+
+# Switch active/non-active nodepools only (does not touch Kubernetes version fields)
+gke-upgrade-tool /path/to/your/env.yaml --switch-active-only
 ```
 
 ### Docker
@@ -136,13 +142,22 @@ jobs:
 $ gke-upgrade-tool dev-keboola-gcp-us-central1/terraform/env.yaml
 🔎 Highest GKE version in file is: 1.25.14-gke.10700
 🎉 Latest GKE version for minor version 1.25 is: 1.25.16-gke.1041000
-🔄 Active pool switched to: B
 ✅ KUBERNETES_VERSION set to 1.25.16-gke.1041000.
 ✅ MAIN_NODE_POOL_B_KUBERNETES_VERSION set to 1.25.16-gke.1041000.
 ✅ ECK_NODE_POOL_B_KUBERNETES_VERSION set to 1.25.16-gke.1041000.
 ✅ JOB_QUEUE_JOBS_NODE_POOL_B_KUBERNETES_VERSION set to 1.25.16-gke.1041000.
 ✅ JOB_QUEUE_JOBS_LARGE_NODE_POOL_B_KUBERNETES_VERSION set to 1.25.16-gke.1041000.
 ✅ SANDBOX_NODE_POOL_B_KUBERNETES_VERSION set to 1.25.16-gke.1041000.
+
+# Switch active/non-active nodepools only
+$ gke-upgrade-tool dev-keboola-gcp-us-central1/terraform/env.yaml --switch-active-only
+🔄 MAIN_NODE_POOL_ACTIVE: a -> b
+🔄 ECK_NODE_POOL_ACTIVE: a -> b
+🔄 JOB_QUEUE_JOBS_NODE_POOL_ACTIVE: a -> b
+🔄 JOB_QUEUE_JOBS_LARGE_NODE_POOL_ACTIVE: a -> b
+🔄 SANDBOX_NODE_POOL_ACTIVE: a -> b
+🔄 All *_NODE_POOL_ACTIVE values switched.
+✅ Switched active nodepools only. Exiting.
 
 # Running again...
 $ gke-upgrade-tool dev-keboola-gcp-us-central1/terraform/env.yaml

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.13"
-    - uses: robinraju/release-downloader@v1.9
+    - uses: robinraju/release-downloader@v1
       with:
         repository: "keboola/gke-upgrade-tool"
         latest: true

--- a/action.yaml
+++ b/action.yaml
@@ -57,45 +57,63 @@ runs:
         if [ $(gh label list | grep -c ${{ inputs.kbc-stack }}) -eq 0 ]; then
           gh label create ${{ inputs.kbc-stack }}
         fi
-    - name: Update env.yaml (Version upgrade and active node pool switch)
+    - name: Update env.yaml (Step 1 - Upgrade control plane and non-active nodepools)
       shell: bash
       run: |
         gke-upgrade-tool $GKE_TOOL_ARGS
-        # If there is git diff, proceed, otherwise exit
         if [ -z "$(git diff)" ]; then
           echo "No changes in the env.yaml file. Exiting."
           exit 0
         else
           git checkout -b ${{ inputs.kbc-stack }}-gke-upgrade-1
-          git commit -am "Upgrade GKE on ${{ inputs.kbc-stack }} #1 (Upgrade GKE, switch active pools)"
+          git commit -am "Upgrade GKE on ${{ inputs.kbc-stack }} #1 (Upgrade control plane and non-active nodepools)"
           git push origin --set-upstream ${{ inputs.kbc-stack }}-gke-upgrade-1
           PR_BODY=$(
           cat <<END_HEREDOC
         $PR_BODY
 
-        Upgrading GKE version and switching active node pools on **${{ inputs.kbc-stack }}** stack.
+        Step 1: Upgrading control plane and non-active nodepools on **${{ inputs.kbc-stack }}** stack.
         END_HEREDOC
         )
-          gh pr create --title "Upgrade GKE on ${{ inputs.kbc-stack }} #1 (Upgrade GKE, switch active pool)" --body "$PR_BODY" --label ${{ inputs.kbc-stack }} --base ${{ github.ref_name }} --head ${{ inputs.kbc-stack }}-gke-upgrade-1
+          gh pr create --title "Upgrade GKE on ${{ inputs.kbc-stack }} #1 (Upgrade control plane and non-active nodepools)" --body "$PR_BODY" --label ${{ inputs.kbc-stack }} --base ${{ github.ref_name }} --head ${{ inputs.kbc-stack }}-gke-upgrade-1
         fi
-    - name: Update env.yaml (Non-active nodepool version upgrade)
+    - name: Update env.yaml (Step 2 - Switch active/non-active nodepools)
       shell: bash
       run: |
-        # If git branch "${{ inputs.kbc-stack }}-gke-upgrade-1" exists, proceed, otherwise exit
         if [ -z "$(git branch --list ${{ inputs.kbc-stack }}-gke-upgrade-1)" ]; then
           echo "Branch ${{ inputs.kbc-stack }}-gke-upgrade-1 does not exist. Exiting."
           exit 0
         else
-          gke-upgrade-tool $GKE_TOOL_ARGS
+          gke-upgrade-tool $GKE_TOOL_ARGS --switch-active-only
           git checkout -b ${{ inputs.kbc-stack }}-gke-upgrade-2
-          git commit -am "Upgrade GKE on ${{ inputs.kbc-stack }} #2 (Upgrade GKE on non-active pools)"
+          git commit -am "Upgrade GKE on ${{ inputs.kbc-stack }} #2 (Switch active/non-active nodepools)"
           git push origin --set-upstream ${{ inputs.kbc-stack }}-gke-upgrade-2
           PR_BODY=$(
           cat <<END_HEREDOC
         $PR_BODY
 
-        Upgrading GKE version on non-active node pools on **${{ inputs.kbc-stack }}** stack.
+        Step 2: Switching active/non-active nodepools on **${{ inputs.kbc-stack }}** stack.
         END_HEREDOC
         )
-          gh pr create --title "Upgrade GKE on ${{ inputs.kbc-stack }} #2 (Upgrade GKE on non-active pool)" --body "$PR_BODY" --label ${{ inputs.kbc-stack }} --base ${{ inputs.kbc-stack }}-gke-upgrade-1 --head ${{ inputs.kbc-stack }}-gke-upgrade-2
+          gh pr create --title "Upgrade GKE on ${{ inputs.kbc-stack }} #2 (Switch active/non-active nodepools)" --body "$PR_BODY" --label ${{ inputs.kbc-stack }} --base ${{ inputs.kbc-stack }}-gke-upgrade-1 --head ${{ inputs.kbc-stack }}-gke-upgrade-2
+        fi
+    - name: Update env.yaml (Step 3 - Upgrade now non-active nodepools)
+      shell: bash
+      run: |
+        if [ -z "$(git branch --list ${{ inputs.kbc-stack }}-gke-upgrade-2)" ]; then
+          echo "Branch ${{ inputs.kbc-stack }}-gke-upgrade-2 does not exist. Exiting."
+          exit 0
+        else
+          gke-upgrade-tool $GKE_TOOL_ARGS
+          git checkout -b ${{ inputs.kbc-stack }}-gke-upgrade-3
+          git commit -am "Upgrade GKE on ${{ inputs.kbc-stack }} #3 (Upgrade now non-active nodepools)"
+          git push origin --set-upstream ${{ inputs.kbc-stack }}-gke-upgrade-3
+          PR_BODY=$(
+          cat <<END_HEREDOC
+        $PR_BODY
+
+        Step 3: Upgrading now non-active nodepools on **${{ inputs.kbc-stack }}** stack.
+        END_HEREDOC
+        )
+          gh pr create --title "Upgrade GKE on ${{ inputs.kbc-stack }} #3 (Upgrade now non-active nodepools)" --body "$PR_BODY" --label ${{ inputs.kbc-stack }} --base ${{ inputs.kbc-stack }}-gke-upgrade-2 --head ${{ inputs.kbc-stack }}-gke-upgrade-3
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -21,10 +21,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - uses: robinraju/release-downloader@v1.9
       with:
         repository: "keboola/gke-upgrade-tool"

--- a/gke_upgrade_tool/Dockerfile
+++ b/gke_upgrade_tool/Dockerfile
@@ -4,6 +4,6 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt --user --no-cache-dir
 FROM cgr.dev/chainguard/python:latest
 WORKDIR /gke_upgrade_tool
-COPY --from=builder /home/nonroot/.local/lib/python3.12/site-packages /home/nonroot/.local/lib/python3.12/site-packages
+COPY --from=builder /home/nonroot/.local/lib/python3.13/site-packages /home/nonroot/.local/lib/python3.13/site-packages
 COPY main.py .
 ENTRYPOINT [ "python", "/gke_upgrade_tool/main.py" ]

--- a/gke_upgrade_tool/main.py
+++ b/gke_upgrade_tool/main.py
@@ -1,6 +1,14 @@
-"""Script that checks available GKE versions
-for specified minor version, switches active A/B node pools and
-updates GKE version in specified env.yaml file.
+"""
+GKE Upgrade Tool
+
+This script upgrades GKE versions in KBC stack env.yaml files. It supports safe, stepwise upgrades of the control plane and nodepools, with clear, colorized, human-friendly CLI output.
+
+Features:
+- Fetches latest GKE versions from the no-channel feed
+- Checks and upgrades the control plane and non-active nodepools to a target version (by default, does NOT switch active/non-active nodepools)
+- Allows explicit switching of active/non-active nodepools with --switch-active-only
+- Provides clear, colorized, sectioned output for all actions and statuses
+- Idempotent: only updates what is needed, and summarizes actions
 
 Usage:
     gke-upgrade-tool <env_file>
@@ -8,12 +16,12 @@ Usage:
     gke-upgrade-tool <env_file> -i <exact_gke_build_version>
     gke-upgrade-tool <env_file> -l
     gke-upgrade-tool <env_file> -m <minor_version> -l
+    gke-upgrade-tool <env_file> --switch-active-only
 
 Example:
     gke-upgrade-tool kbc-stack/terraform/env.yaml
-    gke-upgrade-tool kbc-stack/terraform/env.yaml -m 1.15
-    gke-upgrade-tool kbc-stack/terraform/env.yaml -m 1.15 -l
-    gke-upgrade-tool kbc-stack/terraform/env.yaml -i 1.27.11-gke.1202000
+    gke-upgrade-tool kbc-stack/terraform/env.yaml -m 1.28
+    gke-upgrade-tool kbc-stack/terraform/env.yaml --switch-active-only
 """
 
 import argparse
@@ -26,14 +34,17 @@ from typing import Dict
 import ruamel.yaml
 import requests
 from semver.version import Version
+from colorama import init, Fore, Style
 
 GKE_RELEASE_NOTES = "https://cloud.google.com/feeds/gke-no-channel-release-notes.xml"
 NODE_POOL_ACTIVE_SUFFIX = "_NODE_POOL_ACTIVE"
 
+init(autoreset=True)
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 
 def load_yaml(path: str) -> dict:
+    """Load a YAML file and return its contents as a dict, preserving quotes and formatting."""
     yaml = ruamel.yaml.YAML()
     yaml.preserve_quotes = True
     yaml.width = float("inf")
@@ -42,6 +53,7 @@ def load_yaml(path: str) -> dict:
 
 
 def save_yaml(path: str, content: dict) -> None:
+    """Save a dict to a YAML file, preserving quotes and formatting."""
     yaml = ruamel.yaml.YAML()
     yaml.preserve_quotes = True
     yaml.width = float("inf")
@@ -50,7 +62,7 @@ def save_yaml(path: str, content: dict) -> None:
 
 
 def latest_gke_version(minor_version: str, latest: bool = False) -> str:
-    """Parses GKE release notes feed and returns latest version for specified minor version."""
+    """Fetch the latest (or second to latest) GKE version for a given minor version from the release notes feed."""
     response = requests.get(GKE_RELEASE_NOTES, timeout=10)
     root = ET.fromstring(response.content)
     first_match_found = False
@@ -72,13 +84,13 @@ def latest_gke_version(minor_version: str, latest: bool = False) -> str:
                         else "Latest"
                     )
                     logging.info(
-                        f"🎉 {version_string} GKE version for minor version "
-                        f"{minor_version} is: {latest_gke_versions[0]}"
+                        f"{Style.BRIGHT}{Fore.CYAN}🎉 {version_string} GKE version for minor version "
+                        f"{minor_version} is: {latest_gke_versions[0]}{Style.RESET_ALL}"
                     )
                     return latest_gke_versions[0]
                 logging.warning(
-                    f"😬 No matching GKE version found for minor version "
-                    f"{minor_version}. Versions available are: {unique_values}"
+                    f"{Fore.RED}😬 No matching GKE version found for minor version "
+                    f"{minor_version}. Versions available are: {unique_values}{Style.RESET_ALL}"
                 )
             else:
                 first_match_found = True
@@ -86,7 +98,7 @@ def latest_gke_version(minor_version: str, latest: bool = False) -> str:
 
 
 def current_gke_version(yaml_content: dict) -> str:
-    """Returns current GKE version from env.yaml file."""
+    """Return the highest GKE version found in the env.yaml file (control plane and main nodepools)."""
     control_plane_version = yaml_content["KUBERNETES_VERSION"]
     node_pool_a_version = yaml_content["MAIN_NODE_POOL_A_KUBERNETES_VERSION"]
     node_pool_b_version = yaml_content["MAIN_NODE_POOL_B_KUBERNETES_VERSION"]
@@ -97,12 +109,14 @@ def current_gke_version(yaml_content: dict) -> str:
     current_gke_minor = (
         highest_gke_version.split(".")[0] + "." + highest_gke_version.split(".")[1]
     )
-    logging.info(f"🔎 Highest GKE version in file is: {highest_gke_version}")
+    logging.info(
+        f"{Style.BRIGHT}{Fore.CYAN}🔎 Highest GKE version in file is: {highest_gke_version}{Style.RESET_ALL}"
+    )
     return current_gke_minor
 
 
 def get_active_pool_keys(yaml_content: dict) -> Dict[str, str]:
-    """Returns a dict mapping nodepool label (e.g. MAIN, ECK) to the active pool ('a' or 'b')."""
+    """Return a dict mapping nodepool label (e.g. MAIN, ECK) to the active pool ('a' or 'b')."""
     return {
         key.replace(NODE_POOL_ACTIVE_SUFFIX, ""): value
         for key, value in yaml_content.items()
@@ -111,16 +125,17 @@ def get_active_pool_keys(yaml_content: dict) -> Dict[str, str]:
 
 
 def update_gke_version_only(yaml_content: dict, new_gke_version: str) -> bool:
-    """Updates control plane and non-active nodepools to the new GKE version, with verbose output and idempotency."""
+    """Update the control plane and all non-active nodepools to the new GKE version, with colorized, human-friendly output. Only update what is needed."""
     updated = False
+    print(f"\n{Style.BRIGHT}{Fore.MAGENTA}=== GKE Control Plane ==={Style.RESET_ALL}")
     # Update control plane if needed
     if yaml_content["KUBERNETES_VERSION"] != new_gke_version:
         yaml_content["KUBERNETES_VERSION"] = new_gke_version
-        logging.info(f"✅ KUBERNETES_VERSION set to {new_gke_version}.")
+        print(f"{Fore.GREEN}✅ Upgraded to {new_gke_version}{Style.RESET_ALL}")
         updated = True
     else:
-        logging.info(f"🫡 KUBERNETES_VERSION already at {new_gke_version}.")
-    # Update non-active nodepools if needed
+        print(f"{Fore.YELLOW}🫡 Already at {new_gke_version}{Style.RESET_ALL}")
+    print(f"\n{Style.BRIGHT}{Fore.MAGENTA}=== Nodepools ==={Style.RESET_ALL}")
     active = get_active_pool_keys(yaml_content)
     non_active = {
         label: ("b" if pool == "a" else "a") for label, pool in active.items()
@@ -128,30 +143,47 @@ def update_gke_version_only(yaml_content: dict, new_gke_version: str) -> bool:
     for label, pool in non_active.items():
         key = f"{label}_NODE_POOL_{pool.upper()}_KUBERNETES_VERSION"
         active_key = f"{label}_NODE_POOL_{active[label].upper()}_KUBERNETES_VERSION"
-        logging.info(
-            f"{label}: active pool is '{active[label]}', non-active pool is '{pool}'."
+        active_version = yaml_content.get(active_key, "-")
+        non_active_version = yaml_content.get(key, "-")
+        print(f"{Style.BRIGHT}{label}:{Style.RESET_ALL}")
+        print(
+            f"  • Active: {active[label]} (version: {Fore.CYAN}{active_version}{Style.RESET_ALL})"
+        )
+        print(
+            f"  • Non-active: {pool} (version: {Fore.CYAN}{non_active_version}{Style.RESET_ALL})"
         )
         if key in yaml_content:
             if yaml_content[key] != new_gke_version:
                 yaml_content[key] = new_gke_version
-                logging.info(f"✅ {key} set to {new_gke_version}.")
+                print(
+                    f"  {Fore.GREEN}✅ Upgraded non-active pool '{pool}' to {new_gke_version}{Style.RESET_ALL}"
+                )
                 updated = True
             else:
-                logging.info(f"🫡 {key} already at {new_gke_version}.")
+                print(
+                    f"  {Fore.YELLOW}🫡 Non-active pool '{pool}' already at {new_gke_version}{Style.RESET_ALL}"
+                )
         else:
-            logging.warning(f"⚠️  {key} not found in env.yaml.")
-        if active_key in yaml_content:
-            logging.info(f"{active_key} (active) is at {yaml_content[active_key]}.")
+            print(f"  {Fore.RED}⚠️  {key} not found in env.yaml.{Style.RESET_ALL}")
+        print(
+            f"  {Fore.LIGHTBLACK_EX}{active_key} (active) is at {active_version}{Style.RESET_ALL}"
+        )
     if not updated:
-        logging.info(
-            "🫡 Control plane and all non-active nodepools already at target version. Nothing to do."
+        print(
+            f"\n{Style.BRIGHT}{Fore.GREEN}🫡 Everything is already up-to-date. Nothing to do.{Style.RESET_ALL}"
         )
         return False
+    print(
+        f"\n{Style.BRIGHT}{Fore.GREEN}✔️ Control plane and non-active nodepools upgraded.{Style.RESET_ALL}"
+    )
     return True
 
 
 def switch_only_active_nodepools(yaml_content: dict) -> None:
-    """Switches only the *_NODE_POOL_ACTIVE values between 'a' and 'b' in env.yaml file, and prints what is switching to what."""
+    """Switch all *_NODE_POOL_ACTIVE values between 'a' and 'b', with colorized, human-friendly output."""
+    print(
+        f"\n{Style.BRIGHT}{Fore.MAGENTA}=== Switching Active Nodepools ==={Style.RESET_ALL}"
+    )
     for key, value in yaml_content.items():
         if key.endswith(NODE_POOL_ACTIVE_SUFFIX):
             old_value = value
@@ -160,11 +192,14 @@ def switch_only_active_nodepools(yaml_content: dict) -> None:
             elif value == "b":
                 yaml_content[key] = "a"
             new_value = yaml_content[key]
-            logging.info(f"🔄 {key}: {old_value} -> {new_value}")
-    logging.info("🔄 All *_NODE_POOL_ACTIVE values switched.")
+            print(f"{Fore.CYAN}🔄 {key}: {old_value} -> {new_value}{Style.RESET_ALL}")
+    print(
+        f"{Style.BRIGHT}{Fore.GREEN}🔄 All *_NODE_POOL_ACTIVE values switched.{Style.RESET_ALL}"
+    )
 
 
 def main() -> None:
+    """Parse CLI arguments, perform the requested upgrade or switch, and print colorized, human-friendly output. Handles errors gracefully."""
     parser = argparse.ArgumentParser()
     parser.add_argument("env_file", help="Path to env.yaml file")
     parser.add_argument(
@@ -200,7 +235,9 @@ def main() -> None:
         if args.switch_active_only:
             switch_only_active_nodepools(yaml_content)
             save_yaml(args.env_file, yaml_content)
-            logging.info("✅ Switched active nodepools only. Exiting.")
+            print(
+                f"{Style.BRIGHT}{Fore.GREEN}✅ Switched active nodepools only. Exiting.{Style.RESET_ALL}"
+            )
             return
 
         if args.image and (args.minor or args.latest):
@@ -219,7 +256,7 @@ def main() -> None:
         if updated:
             save_yaml(args.env_file, yaml_content)
     except Exception as e:
-        logging.error(f"❌ Error: {e}")
+        print(f"{Style.BRIGHT}{Fore.RED}❌ Error: {e}{Style.RESET_ALL}")
         exit(1)
 
 

--- a/gke_upgrade_tool/requirements.txt
+++ b/gke_upgrade_tool/requirements.txt
@@ -1,3 +1,4 @@
-Requests==2.31.0
-ruamel.yaml==0.18.5
-semver==3.0.2
+colorama==0.4.6
+Requests==2.32.3
+ruamel.yaml==0.18.10
+semver==3.0.4

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setuptools.setup(
     description="Prepares KBC Stacks env.yaml for GKE upgrade",
     packages=setuptools.find_packages(),
     entry_points={"console_scripts": ["gke-upgrade-tool = gke_upgrade_tool.main:main"]},
-    install_requires=["ruamel.yaml", "requests", "semver"],
+    install_requires=["colorama", "ruamel.yaml", "requests", "semver"],
     setuptools_git_versioning={
         "enabled": True,
     },


### PR DESCRIPTION
Fixes [ST-3108](https://keboola.atlassian.net/browse/ST-3108).

There was an issue with switching A/B nodepools, while upgrading them at the same time. It happened in the [same](https://github.com/keboola/infrastructure/actions/runs/15029281244/job/42237657430) `terraform apply`, but was in wrong order, or more importantly _no order at all_:
- Control plane got upgraded.
- Nodepool taints were modified to switch between non-active and active nodepools.
- At the moment of merge non-active nodepools started to being upgraded.

This could caused a problem, when the switch between A/B was already done, but workload kept coming, and non-upgraded now active nodepools had pods scheduled. However immediate K8s upgrade directed by control plane started force-terminating these switched nodes, even with workload. This meant [jobs were stopped](https://keboolaglobal.slack.com/archives/CGCKT849E/p1747295868708509).

Easiest solution is break these into 3 separate PRs, instead of just 2:
- Upgrade Kubernets version of control plane, and the non-active nodepools.
- Switch active/non-active nodepools.
- Upgrade newly non-active nodepools.

Tested on `canary-orion`:
- [The workflow](https://github.com/keboola/kbc-stacks/actions/runs/15053008231/job/42312143584)
- https://github.com/keboola/kbc-stacks/pull/3411
- https://github.com/keboola/kbc-stacks/pull/3412
- https://github.com/keboola/kbc-stacks/pull/3413

[ST-3108]: https://keboola.atlassian.net/browse/ST-3108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ