### PR TITLE
fix: Only rewrite explicitly modified keys in tfvars.write() [ST-3802]

### DIFF
--- a/gke_upgrade_tool/main.py
+++ b/gke_upgrade_tool/main.py
@@ -116,15 +116,18 @@ def discover_version_keys(values: dict, pool_letter: str) -> list:
     return [k for k in values if k.endswith(suffix) and k.startswith("node_pool_")]
 
 
-def update_gke_version(values: dict, new_gke_version: str) -> bool:
-    """Update the control plane and all non-active nodepools to the new GKE version."""
-    updated = False
+def update_gke_version(values: dict, new_gke_version: str) -> set:
+    """Update the control plane and all non-active nodepools to the new GKE version.
+
+    Returns the set of keys that were actually modified (empty if nothing changed).
+    """
+    modified = set()
 
     print(f"\n{Style.BRIGHT}{Fore.MAGENTA}=== GKE Control Plane ==={Style.RESET_ALL}")
     if values["kubernetes_version"] != new_gke_version:
         values["kubernetes_version"] = new_gke_version
         print(f"{Fore.GREEN}✅ Upgraded to {new_gke_version}{Style.RESET_ALL}")
-        updated = True
+        modified.add("kubernetes_version")
     else:
         print(f"{Fore.YELLOW}🫡 Already at {new_gke_version}{Style.RESET_ALL}")
 
@@ -155,7 +158,7 @@ def update_gke_version(values: dict, new_gke_version: str) -> bool:
                 print(
                     f"  {Fore.GREEN}✅ Upgraded non-active pool '{non_active_letter}' to {new_gke_version}{Style.RESET_ALL}"
                 )
-                updated = True
+                modified.add(non_active_key)
             else:
                 print(
                     f"  {Fore.YELLOW}🫡 Non-active pool '{non_active_letter}' already at {new_gke_version}{Style.RESET_ALL}"
@@ -167,32 +170,38 @@ def update_gke_version(values: dict, new_gke_version: str) -> bool:
             f"  {Fore.LIGHTBLACK_EX}{active_key} (active) is at {active_version}{Style.RESET_ALL}"
         )
 
-    if not updated:
+    if not modified:
         print(
             f"\n{Style.BRIGHT}{Fore.GREEN}🫡 Everything is already up-to-date. Nothing to do.{Style.RESET_ALL}"
         )
-        return False
+        return modified
 
     print(
         f"\n{Style.BRIGHT}{Fore.GREEN}✔️ Control plane and non-active nodepools upgraded.{Style.RESET_ALL}"
     )
-    return True
+    return modified
 
 
-def switch_only_active_nodepools(values: dict) -> None:
-    """Switch all node_pool_*_active values between 'a' and 'b'."""
+def switch_only_active_nodepools(values: dict) -> set:
+    """Switch all node_pool_*_active values between 'a' and 'b'.
+
+    Returns the set of keys that were modified.
+    """
     print(
         f"\n{Style.BRIGHT}{Fore.MAGENTA}=== Switching Active Nodepools ==={Style.RESET_ALL}"
     )
+    modified = set()
     active_pools = discover_pool_active_keys(values)
     for pool_name, active_letter in active_pools.items():
         key = f"node_pool_{pool_name}_active"
         new_letter = "b" if active_letter == "a" else "a"
         values[key] = new_letter
+        modified.add(key)
         print(f"{Fore.CYAN}🔄 {key}: {active_letter} -> {new_letter}{Style.RESET_ALL}")
     print(
         f"{Style.BRIGHT}{Fore.GREEN}🔄 All active nodepool flags switched.{Style.RESET_ALL}"
     )
+    return modified
 
 
 def main() -> None:
@@ -228,8 +237,9 @@ def main() -> None:
         values, lines = tfvars.read(args.config_file)
 
         if args.switch_active_only:
-            switch_only_active_nodepools(values)
-            tfvars.write(args.config_file, values, lines)
+            modified = switch_only_active_nodepools(values)
+            if modified:
+                tfvars.write(args.config_file, values, lines, modified)
             print(
                 f"{Style.BRIGHT}{Fore.GREEN}✅ Switched active nodepools only. Exiting.{Style.RESET_ALL}"
             )
@@ -251,9 +261,9 @@ def main() -> None:
             print(f"{Fore.RED}❌ Could not determine target GKE version. Exiting.{Style.RESET_ALL}")
             exit(1)
 
-        updated = update_gke_version(values, new_gke_version)
-        if updated:
-            tfvars.write(args.config_file, values, lines)
+        modified = update_gke_version(values, new_gke_version)
+        if modified:
+            tfvars.write(args.config_file, values, lines, modified)
 
     except Exception as e:
         print(f"{Style.BRIGHT}{Fore.RED}❌ Error: {e}{Style.RESET_ALL}")

--- a/gke_upgrade_tool/tfvars.py
+++ b/gke_upgrade_tool/tfvars.py
@@ -57,21 +57,30 @@ def read(filepath):
     return values, lines
 
 
-def write(filepath, values, lines):
-    """Write a .tfvars file back, updating only changed values.
+def write(filepath, values, lines, modified_keys):
+    """Write a .tfvars file back, rewriting only the given top-level keys.
+
+    The parser does not understand nested HCL maps, so inner keys from nested
+    objects (e.g. big_query_backends.*.folder_display_name) end up flattened
+    into the values dict. Rewriting every line whose key appears in values
+    would corrupt those nested blocks. Callers must therefore pass the
+    explicit set of top-level keys they intend to change.
 
     Args:
         filepath: path to write
         values: dict of key->value (the modified values)
         lines: original lines list (from read())
+        modified_keys: iterable of top-level key names that should be rewritten
     """
+    modified_keys = set(modified_keys)
     output = []
+    rewritten = set()
 
     for line in lines:
         m = _KV_PATTERN.match(line)
         if m:
             key = m.group(2)
-            if key in values:
+            if key in modified_keys and key not in rewritten:
                 indent = m.group(1)
                 separator = m.group(3)
                 old_raw = m.group(4).strip()
@@ -86,9 +95,16 @@ def write(filepath, values, lines):
                     new_raw = new_val
 
                 output.append(f"{indent}{key}{separator}{new_raw}{trailing}")
+                rewritten.add(key)
                 continue
 
         output.append(line)
+
+    missing = modified_keys - rewritten
+    if missing:
+        raise KeyError(
+            f"Refusing to write: modified keys not found as top-level lines: {sorted(missing)}"
+        )
 
     with open(filepath, "w", encoding="utf-8") as f:
         f.write("\n".join(output) + "\n")


### PR DESCRIPTION
## Summary

Fixes a critical bug where `gke-upgrade-tool` was silently rewriting nested HCL fields in `infrastructure.tfvars`, corrupting `big_query_backends` configuration and triggering BigQuery resource replacement in generated upgrade PRs (e.g. [kbc-stacks#15805](https://github.com/keboola/kbc-stacks/pull/15805)).


### Local test
Generated PR - https://github.com/keboola/kbc-stacks/pull/15831

```
v run gke-upgrade-tool ~/Development/projects/kbc-stacks/com-keboola-gcp-us-east4/infrastructure.tfvars -m 1.34
🎉 Second to latest GKE version for minor version 1.34 is: 1.34.6-gke.1154000

=== GKE Control Plane ===
✅ Upgraded to 1.34.6-gke.1154000

=== Nodepools ===
main:
  • Active: a (version: 1.33.5-gke.1162000)
  • Non-active: b (version: 1.33.5-gke.1162000)
  ✅ Upgraded non-active pool 'b' to 1.34.6-gke.1154000
  node_pool_main_a_kubernetes_version (active) is at 1.33.5-gke.1162000
job_queue_jobs:
  • Active: a (version: 1.33.5-gke.1162000)
  • Non-active: b (version: 1.33.5-gke.1162000)
  ✅ Upgraded non-active pool 'b' to 1.34.6-gke.1154000
  node_pool_job_queue_jobs_a_kubernetes_version (active) is at 1.33.5-gke.1162000
job_queue_jobs_large:
  • Active: a (version: 1.33.5-gke.1162000)
  • Non-active: b (version: 1.33.5-gke.1162000)
  ✅ Upgraded non-active pool 'b' to 1.34.6-gke.1154000
  node_pool_job_queue_jobs_large_a_kubernetes_version (active) is at 1.33.5-gke.1162000
sandbox:
  • Active: a (version: 1.33.5-gke.1162000)
  • Non-active: b (version: 1.33.5-gke.1162000)
  ✅ Upgraded non-active pool 'b' to 1.34.6-gke.1154000
  node_pool_sandbox_a_kubernetes_version (active) is at 1.33.5-gke.1162000
job_queue_jobs_short_run_time:
  • Active: a (version: 1.33.5-gke.1162000)
  • Non-active: b (version: 1.33.5-gke.1162000)
  ✅ Upgraded non-active pool 'b' to 1.34.6-gke.1154000
  node_pool_job_queue_jobs_short_run_time_a_kubernetes_version (active) is at 1.33.5-gke.1162000
job_queue_jobs_long_run_time:
  • Active: a (version: 1.33.5-gke.1162000)
  • Non-active: b (version: 1.33.5-gke.1162000)
  ✅ Upgraded non-active pool 'b' to 1.34.6-gke.1154000
  node_pool_job_queue_jobs_long_run_time_a_kubernetes_version (active) is at 1.33.5-gke.1162000
job_queue_jobs_nodind:
  • Active: a (version: 1.33.5-gke.1162000)
  • Non-active: b (version: 1.33.5-gke.1162000)
  ✅ Upgraded non-active pool 'b' to 1.34.6-gke.1154000
  node_pool_job_queue_jobs_nodind_a_kubernetes_version (active) is at 1.33.5-gke.1162000
job_queue_jobs_nodind_large:
  • Active: a (version: 1.33.5-gke.1162000)
  • Non-active: b (version: 1.33.5-gke.1162000)
  ✅ Upgraded non-active pool 'b' to 1.34.6-gke.1154000
  node_pool_job_queue_jobs_nodind_large_a_kubernetes_version (active) is at 1.33.5-gke.1162000
job_queue_jobs_nodind_short_run_time:
  • Active: a (version: 1.33.5-gke.1162000)
  • Non-active: b (version: 1.33.5-gke.1162000)
  ✅ Upgraded non-active pool 'b' to 1.34.6-gke.1154000
  node_pool_job_queue_jobs_nodind_short_run_time_a_kubernetes_version (active) is at 1.33.5-gke.1162000
job_queue_jobs_nodind_long_run_time:
  • Active: a (version: 1.33.5-gke.1162000)
  • Non-active: b (version: 1.33.5-gke.1162000)
  ✅ Upgraded non-active pool 'b' to 1.34.6-gke.1154000
  node_pool_job_queue_jobs_nodind_long_run_time_a_kubernetes_version (active) is at 1.33.5-gke.1162000

✔️ Control plane and non-active nodepools upgraded.
```

### Root cause

The tfvars parser in `gke_upgrade_tool/tfvars.py` doesn't understand nested HCL maps (`{ ... }`). Inner keys from nested objects — e.g. `big_query_backends.*.folder_display_name`, `reservations.name`, `slot_capacity` — get flattened into the top-level `values` dict with last-write-wins semantics.

`write()` then rewrote every line whose key appeared in `values`, which broadcast the last-seen inner value across every nested block that shared the inner key name.

On `com-keboola-gcp-us-east4`, the last (5th) backend `contracts-backend-1` "won", so its values were written into the first four backends — changing `folder_display_name`, `backend_prefix`, `reservations.name`, `slot_capacity`, `assignment_folder_id`, and `assignment_id`. Terraform would treat these as resource replacements.

### Fix

`write()` now requires an explicit `modified_keys` set and rewrites only those top-level lines. `update_gke_version()` and `switch_only_active_nodepools()` return the keys they actually touched, and `main()` passes that set to `write()`.

Each key is rewritten at most once (guards against top-level/inner-key name collisions). `write()` raises `KeyError` if a requested key isn't found, failing loud instead of silently dropping the change.

Relates to [ST-3802](https://keboola.atlassian.net/browse/ST-3802).

## Test plan

- [x] Local reproduction: fetched `com-keboola-gcp-us-east4/infrastructure.tfvars` from `main`, ran the fixed tool against it targeting `1.34.6-gke.1154000`. Resulting diff touches only `kubernetes_version` lines — zero `big_query_backends` fields affected. Parser still flattens BQ fields into `values` (confirmed by dumping the dict), but `write()` now ignores them.
- [ ] Generate a dry-run upgrade PR against a stack with the fixed tool and confirm only k8s version fields change.
- [ ] Audit other recently-generated GKE upgrade PRs on `kbc-stacks` for latent corruption of nested blocks.

## Follow-ups (not in this PR)

- Parser itself still silently flattens nested `{...}` maps. A future change should track brace depth in `read()` so the `values` dict stops being misleading for future callers.