### PR TITLE
Pin action's Docker image to github.action_ref [ST-3802]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [CLI reference](#cli-reference)
 - [Example output](#example-output)
 - [Recovery](#recovery)
+- [Releasing](#releasing)
 
 ## Overview
 
@@ -259,3 +260,26 @@ main:
 - Each PR is independent — you can merge or revert individual phases
 - To undo a pool switch: run `--switch-active-only` again (it toggles a↔b)
 - If the Google feed is temporarily unavailable: use `-i` with a known version to bypass the feed
+
+## Releasing
+
+Releases are driven by git tags. Pushing a tag matching `v*` triggers [`.github/workflows/main.yaml`](.github/workflows/main.yaml), which:
+
+1. Builds the Python package and attaches the tarball to a new GitHub Release (auto-generated notes).
+2. Builds and pushes a multi-arch Docker image to `ghcr.io/keboola/gke-upgrade-tool` tagged with the version (e.g. `v0.1.2`).
+
+The composite `action.yaml` pulls the Docker image using `${{ github.action_ref }}`, so the image tag always matches the ref the caller pins (`keboola/gke-upgrade-tool@v0.1.2` → `ghcr.io/keboola/gke-upgrade-tool:v0.1.2`). No manual version sync in `action.yaml` is needed.
+
+### Cutting a release
+
+1. Merge all changes to `main`.
+2. Create and push an annotated tag:
+
+    ```bash
+    git checkout main && git pull
+    git tag -a v0.1.3 -m "v0.1.3"
+    git push origin v0.1.3
+    ```
+
+3. Wait for the `Build and Publish` workflow to finish — verify the [release](https://github.com/keboola/gke-upgrade-tool/releases) and the matching [Docker image](https://github.com/keboola/gke-upgrade-tool/pkgs/container/gke-upgrade-tool) tag exist.
+4. Bump consumers (e.g. `keboola/kbc-stacks`) to the new `keboola/gke-upgrade-tool@vX.Y.Z` ref.

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
       shell: bash
       run: |
         docker run --rm --user "$(id -u):$(id -g)" -v "${{ github.workspace }}:/workspace" -w /workspace \
-          ghcr.io/keboola/gke-upgrade-tool:v0.1.1 $GKE_TOOL_ARGS
+          ghcr.io/keboola/gke-upgrade-tool:${{ github.action_ref }} $GKE_TOOL_ARGS
         if [ -z "$(git diff)" ]; then
           echo "No changes in infrastructure.tfvars. Exiting."
           exit 0
@@ -77,7 +77,7 @@ runs:
           exit 0
         else
           docker run --rm --user "$(id -u):$(id -g)" -v "${{ github.workspace }}:/workspace" -w /workspace \
-            ghcr.io/keboola/gke-upgrade-tool:v0.1.1 $GKE_TOOL_ARGS --switch-active-only
+            ghcr.io/keboola/gke-upgrade-tool:${{ github.action_ref }} $GKE_TOOL_ARGS --switch-active-only
           git checkout -b ${{ inputs.kbc-stack }}-gke-upgrade-2
           git commit -am "Upgrade GKE on ${{ inputs.kbc-stack }} #2 (Switch active/non-active nodepools)"
           git push origin --set-upstream ${{ inputs.kbc-stack }}-gke-upgrade-2
@@ -98,7 +98,7 @@ runs:
           exit 0
         else
           docker run --rm --user "$(id -u):$(id -g)" -v "${{ github.workspace }}:/workspace" -w /workspace \
-            ghcr.io/keboola/gke-upgrade-tool:v0.1.1 $GKE_TOOL_ARGS
+            ghcr.io/keboola/gke-upgrade-tool:${{ github.action_ref }} $GKE_TOOL_ARGS
           git checkout -b ${{ inputs.kbc-stack }}-gke-upgrade-3
           git commit -am "Upgrade GKE on ${{ inputs.kbc-stack }} #3 (Upgrade now non-active nodepools)"
           git push origin --set-upstream ${{ inputs.kbc-stack }}-gke-upgrade-3


### PR DESCRIPTION
## Summary

- Replace hardcoded `ghcr.io/keboola/gke-upgrade-tool:v0.1.1` in `action.yaml` with `${{ github.action_ref }}` on all three `docker run` lines, so the image tag tracks the caller's ref automatically and cannot drift on future releases.
- Add a **Releasing** section to `README.md` documenting the tag-driven release workflow and the `github.action_ref` pinning behavior.

## Why

After releasing `v0.1.2`, callers pinning `keboola/gke-upgrade-tool@v0.1.2` still ran the `v0.1.1` Docker image because `action.yaml` at the v0.1.2 tag still hardcoded `:v0.1.1`. See [kbc-stacks#15865](https://github.com/keboola/kbc-stacks/pull/15865) and the [failing run](https://github.com/keboola/kbc-stacks/actions/runs/24778154330/job/72501774586). With `github.action_ref`, `@v0.1.2` → pulls `:v0.1.2`, `@main` → pulls `:main`, no manual sync at release time.

Related: [ST-3802](https://keboola.atlassian.net/browse/ST-3802)

## Test plan

- [ ] Merge this PR and cut a `v0.1.3` release tag.
- [ ] Confirm `.github/workflows/main.yaml` publishes both the GitHub release and the `ghcr.io/keboola/gke-upgrade-tool:v0.1.3` image.
- [ ] Open a kbc-stacks PR bumping to `keboola/gke-upgrade-tool@v0.1.3` and verify the workflow logs show the v0.1.3 image being pulled.