### PR TITLE
fix: Hardcode Docker image tag in action.yaml [ST-3802]

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ docker run --rm \
 <summary>Minimal example</summary>
 
 ```yaml
-- uses: "keboola/gke-upgrade-tool@v0.1.0"
+- uses: "keboola/gke-upgrade-tool@v0.1.4"
   with:
     kbc-stack: "dev-keboola-gcp-us-central1"
 ```
@@ -160,7 +160,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: "keboola/gke-upgrade-tool@v0.1.0"
+      - uses: "keboola/gke-upgrade-tool@v0.1.4"
         with:
           kbc-stack: ${{ inputs.kbc-stack }}
           gke-minor-version: ${{ inputs.gke-minor-version }}
@@ -266,20 +266,37 @@ main:
 Releases are driven by git tags. Pushing a tag matching `v*` triggers [`.github/workflows/main.yaml`](.github/workflows/main.yaml), which:
 
 1. Builds the Python package and attaches the tarball to a new GitHub Release (auto-generated notes).
-2. Builds and pushes a multi-arch Docker image to `ghcr.io/keboola/gke-upgrade-tool` tagged with the version (e.g. `v0.1.2`).
+2. Builds and pushes a multi-arch Docker image to `ghcr.io/keboola/gke-upgrade-tool` tagged with the version (e.g. `v0.1.4`).
 
-The composite `action.yaml` pulls the Docker image using `${{ github.action_ref }}`, so the image tag always matches the ref the caller pins (`keboola/gke-upgrade-tool@v0.1.2` → `ghcr.io/keboola/gke-upgrade-tool:v0.1.2`). No manual version sync in `action.yaml` is needed.
+### Image tag in `action.yaml` must be bumped before tagging
+
+The composite `action.yaml` hardcodes the Docker image tag on three `docker run` lines:
+
+```yaml
+ghcr.io/keboola/gke-upgrade-tool:vX.Y.Z
+```
+
+This tag **must** be updated in the same commit as the release, before the git tag is pushed. We intentionally do not use `${{ github.action_ref }}` — it is [empty in composite action `run:` steps](https://github.com/actions/runner/issues/2473), which silently breaks the image reference at caller runtime.
 
 ### Cutting a release
 
 1. Merge all changes to `main`.
-2. Create and push an annotated tag:
+2. On `main`, bump the image tag in `action.yaml` (three occurrences — one per `docker run` step) to the new version, and bump the minimal example versions in `README.md`. Commit with a message like `chore: Release v0.1.4`.
 
     ```bash
     git checkout main && git pull
-    git tag -a v0.1.3 -m "v0.1.3"
-    git push origin v0.1.3
+    sed -i '' 's|ghcr.io/keboola/gke-upgrade-tool:v[0-9.]*|ghcr.io/keboola/gke-upgrade-tool:v0.1.4|g' action.yaml
+    # review README.md and bump the two `keboola/gke-upgrade-tool@vX.Y.Z` example refs
+    git commit -am "chore: Release v0.1.4"
+    git push origin main
     ```
 
-3. Wait for the `Build and Publish` workflow to finish — verify the [release](https://github.com/keboola/gke-upgrade-tool/releases) and the matching [Docker image](https://github.com/keboola/gke-upgrade-tool/pkgs/container/gke-upgrade-tool) tag exist.
-4. Bump consumers (e.g. `keboola/kbc-stacks`) to the new `keboola/gke-upgrade-tool@vX.Y.Z` ref.
+3. Create and push an annotated tag pointing at that release commit:
+
+    ```bash
+    git tag -a v0.1.4 -m "v0.1.4"
+    git push origin v0.1.4
+    ```
+
+4. Wait for the `Build and Publish` workflow to finish — verify the [release](https://github.com/keboola/gke-upgrade-tool/releases) and the matching [Docker image](https://github.com/keboola/gke-upgrade-tool/pkgs/container/gke-upgrade-tool) tag exist.
+5. Bump consumers (e.g. `keboola/kbc-stacks`) to the new `keboola/gke-upgrade-tool@vX.Y.Z` ref.

--- a/README.md
+++ b/README.md
@@ -280,23 +280,33 @@ This tag **must** be updated in the same commit as the release, before the git t
 
 ### Cutting a release
 
-1. Merge all changes to `main`.
-2. On `main`, bump the image tag in `action.yaml` (three occurrences — one per `docker run` step) to the new version, and bump the minimal example versions in `README.md`. Commit with a message like `chore: Release v0.1.4`.
+`main` is protected — all version bumps must land via a pull request.
+
+1. Create a release-bump branch off the latest `main`:
 
     ```bash
     git checkout main && git pull
-    sed -i '' 's|ghcr.io/keboola/gke-upgrade-tool:v[0-9.]*|ghcr.io/keboola/gke-upgrade-tool:v0.1.4|g' action.yaml
-    # review README.md and bump the two `keboola/gke-upgrade-tool@vX.Y.Z` example refs
-    git commit -am "chore: Release v0.1.4"
-    git push origin main
+    git checkout -b release/v0.1.4
     ```
 
-3. Create and push an annotated tag pointing at that release commit:
+2. Bump the image tag in `action.yaml` (three occurrences — one per `docker run` step) and the two minimal-example refs in `README.md`:
 
     ```bash
+    sed -i '' 's|ghcr.io/keboola/gke-upgrade-tool:v[0-9.]*|ghcr.io/keboola/gke-upgrade-tool:v0.1.4|g' action.yaml
+    sed -i '' 's|keboola/gke-upgrade-tool@v[0-9.]*|keboola/gke-upgrade-tool@v0.1.4|g' README.md
+    git commit -am "chore: Release v0.1.4"
+    git push -u origin release/v0.1.4
+    ```
+
+3. Open a PR against `main`, get it reviewed, and merge it.
+
+4. Create and push an annotated tag pointing at the merge commit on `main`:
+
+    ```bash
+    git checkout main && git pull
     git tag -a v0.1.4 -m "v0.1.4"
     git push origin v0.1.4
     ```
 
-4. Wait for the `Build and Publish` workflow to finish — verify the [release](https://github.com/keboola/gke-upgrade-tool/releases) and the matching [Docker image](https://github.com/keboola/gke-upgrade-tool/pkgs/container/gke-upgrade-tool) tag exist.
-5. Bump consumers (e.g. `keboola/kbc-stacks`) to the new `keboola/gke-upgrade-tool@vX.Y.Z` ref.
+5. Wait for the `Build and Publish` workflow to finish — verify the [release](https://github.com/keboola/gke-upgrade-tool/releases) and the matching [Docker image](https://github.com/keboola/gke-upgrade-tool/pkgs/container/gke-upgrade-tool) tag exist.
+6. Bump consumers (e.g. `keboola/kbc-stacks`) to the new `keboola/gke-upgrade-tool@vX.Y.Z` ref.

--- a/action.yaml
+++ b/action.yaml
@@ -52,7 +52,7 @@ runs:
       shell: bash
       run: |
         docker run --rm --user "$(id -u):$(id -g)" -v "${{ github.workspace }}:/workspace" -w /workspace \
-          ghcr.io/keboola/gke-upgrade-tool:${{ github.action_ref }} $GKE_TOOL_ARGS
+          ghcr.io/keboola/gke-upgrade-tool:v0.1.4 $GKE_TOOL_ARGS
         if [ -z "$(git diff)" ]; then
           echo "No changes in infrastructure.tfvars. Exiting."
           exit 0
@@ -77,7 +77,7 @@ runs:
           exit 0
         else
           docker run --rm --user "$(id -u):$(id -g)" -v "${{ github.workspace }}:/workspace" -w /workspace \
-            ghcr.io/keboola/gke-upgrade-tool:${{ github.action_ref }} $GKE_TOOL_ARGS --switch-active-only
+            ghcr.io/keboola/gke-upgrade-tool:v0.1.4 $GKE_TOOL_ARGS --switch-active-only
           git checkout -b ${{ inputs.kbc-stack }}-gke-upgrade-2
           git commit -am "Upgrade GKE on ${{ inputs.kbc-stack }} #2 (Switch active/non-active nodepools)"
           git push origin --set-upstream ${{ inputs.kbc-stack }}-gke-upgrade-2
@@ -98,7 +98,7 @@ runs:
           exit 0
         else
           docker run --rm --user "$(id -u):$(id -g)" -v "${{ github.workspace }}:/workspace" -w /workspace \
-            ghcr.io/keboola/gke-upgrade-tool:${{ github.action_ref }} $GKE_TOOL_ARGS
+            ghcr.io/keboola/gke-upgrade-tool:v0.1.4 $GKE_TOOL_ARGS
           git checkout -b ${{ inputs.kbc-stack }}-gke-upgrade-3
           git commit -am "Upgrade GKE on ${{ inputs.kbc-stack }} #3 (Upgrade now non-active nodepools)"
           git push origin --set-upstream ${{ inputs.kbc-stack }}-gke-upgrade-3


### PR DESCRIPTION
## Summary

`keboola/gke-upgrade-tool@v0.1.2` and `@v0.1.3` fail at caller runtime with:

```
docker: invalid reference format
```

because `${{ github.action_ref }}` is empty inside composite action `run:` steps — a [known GitHub Actions runner limitation](https://github.com/actions/runner/issues/2473). The rendered docker image reference becomes `ghcr.io/keboola/gke-upgrade-tool:` (empty tag, trailing colon).

Evidence: https://github.com/keboola/kbc-stacks/actions/runs/24780919262/job/72511521559

## Fix

Revert the image tag to a hardcoded `v0.1.4` on all three `docker run` lines in `action.yaml` — the pattern that worked in `v0.1.1`.

Rewrite the README "Releasing" section so it:

1. Explains why `${{ github.action_ref }}` cannot be used (links to the runner issue), and
2. Requires the release commit to bump the three `action.yaml` image-tag lines **before** pushing the git tag.

Also bump the two `v0.1.0` example refs in README to `v0.1.4` so copy-paste users land on a working version.

## Test plan

- [ ] Merge this PR.
- [ ] Push tag `v0.1.4`.
- [ ] Confirm the `Build and Publish` workflow publishes `ghcr.io/keboola/gke-upgrade-tool:v0.1.4`.
- [ ] Bump `keboola/kbc-stacks` to `keboola/gke-upgrade-tool@v0.1.4` and re-run the GKE upgrade workflow against a dev stack — verify the docker step succeeds.

## Related

- ST-3802
- Reverts the `action.yaml` change from #108 (commit 844bad09)